### PR TITLE
Remove Duplicate Configuration Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ntpMerlin
 
 ## v3.4.8
-### Updated on 2025-June-04
+### Updated on 2025-June-07
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.
 


### PR DESCRIPTION
Added/modified code to remove duplicate parameter key names found in the configuration file.
Getting some duplicate key values can cause "bad number" or "arithmetic syntax" errors.