### PR TITLE
Fixes and Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ntpMerlin
 
-## v3.4.8
-### Updated on 2025-June-21
+## v3.4.9
+### Updated on 2025-July-16
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.
 

--- a/S77chronyd
+++ b/S77chronyd
@@ -8,7 +8,6 @@ if [ "$1" = "restart" ] || [ "$1" = "stop" ] || [ "$1" = "kill" ]; then
 	killall -q chronyd
 fi
 
-
 ENABLED=yes
 PROCS=timeserverd
 ARGS="S77chronyd"

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -14,7 +14,7 @@
 ##     Forked from https://github.com/jackyaz/ntpMerlin     ##
 ##                                                          ##
 ##############################################################
-# Last Modified: 2025-Jun-21
+# Last Modified: 2025-Jul-16
 #-------------------------------------------------------------
 
 ###############       Shellcheck directives      #############
@@ -36,8 +36,8 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="ntpMerlin"
 readonly SCRIPT_NAME_LOWER="$(echo "$SCRIPT_NAME" | tr 'A-Z' 'a-z' | sed 's/d//')"
-readonly SCRIPT_VERSION="v3.4.8"
-readonly SCRIPT_VERSTAG="25062121"
+readonly SCRIPT_VERSION="v3.4.9"
+readonly SCRIPT_VERSTAG="25071601"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
@@ -68,7 +68,6 @@ readonly scriptVERINFO="[${SCRIPT_VERSION}_${SCRIPT_VERSTAG}, Branch: $SCRIPT_BR
 readonly defTrimDB_Hour=3
 readonly defTrimDB_Mins=7
 
-readonly oneHrSec=3600
 readonly _12Hours=43200
 readonly _24Hours=86400
 readonly _36Hours=129600
@@ -104,6 +103,7 @@ readonly CLEARFORMAT="\\e[0m"
 readonly CLRct="\e[0m"
 readonly REDct="\e[1;31m"
 readonly GRNct="\e[1;32m"
+readonly MGNTct="\e[1;35m"
 readonly CritIREDct="\e[41m"
 readonly CritBREDct="\e[30;101m"
 readonly PassBGRNct="\e[30;102m"
@@ -291,10 +291,12 @@ Update_Version()
 					Update_File shared-jy.tar.gz
 					Update_File timeserverd
 					TIMESERVER_NAME="$(TimeServer check)"
-					if [ "$TIMESERVER_NAME" = "ntpd" ]; then
+					if [ "$TIMESERVER_NAME" = "ntpd" ]
+					then
 						Update_File S77ntpd
 						Update_File ntp.conf
-					elif [ "$TIMESERVER_NAME" = "chronyd" ]; then
+					elif [ "$TIMESERVER_NAME" = "chronyd" ]
+					then
 						Update_File S77chronyd
 						Update_File chrony.conf
 					fi
@@ -329,10 +331,12 @@ Update_Version()
 		Update_File shared-jy.tar.gz
 		Update_File timeserverd
 		TIMESERVER_NAME="$(TimeServer check)"
-		if [ "$TIMESERVER_NAME" = "ntpd" ]; then
+		if [ "$TIMESERVER_NAME" = "ntpd" ]
+		then
 			Update_File ntp.conf
 			Update_File S77ntpd
-		elif [ "$TIMESERVER_NAME" = "chronyd" ]; then
+		elif [ "$TIMESERVER_NAME" = "chronyd" ]
+		then
 			Update_File chrony.conf
 			Update_File S77chronyd
 		fi
@@ -364,7 +368,8 @@ Update_File()
 	then
 		tmpfile="/tmp/$1"
 		Download_File "$SCRIPT_REPO/$1" "$tmpfile"
-		if ! diff -q "$tmpfile" "/opt/etc/init.d/$1" >/dev/null 2>&1; then
+		if ! diff -q "$tmpfile" "/opt/etc/init.d/$1" >/dev/null 2>&1
+		then
 			Print_Output true "New version of $1 downloaded" "$PASS"
 			TimeServer_Customise
 		fi
@@ -557,15 +562,15 @@ Create_Dirs()
 Create_Symlinks()
 {
 	rm -rf "${SCRIPT_WEB_DIR:?}/"* 2>/dev/null
-	
+
 	ln -s /tmp/detect_ntpmerlin.js "$SCRIPT_WEB_DIR/detect_ntpmerlin.js" 2>/dev/null
 	ln -s "$SCRIPT_STORAGE_DIR/ntpstatstext.js" "$SCRIPT_WEB_DIR/ntpstatstext.js" 2>/dev/null
 	ln -s "$SCRIPT_STORAGE_DIR/lastx.csv" "$SCRIPT_WEB_DIR/lastx.htm" 2>/dev/null
-	
+
 	ln -s "$SCRIPT_CONF" "$SCRIPT_WEB_DIR/config.htm" 2>/dev/null
-	
+
 	ln -s "$CSV_OUTPUT_DIR" "$SCRIPT_WEB_DIR/csv" 2>/dev/null
-	
+
 	if [ ! -d "$SHARED_WEB_DIR" ]; then
 		ln -s "$SHARED_DIR" "$SHARED_WEB_DIR" 2>/dev/null
 	fi
@@ -1143,10 +1148,14 @@ _CheckFor_WebGUI_Page_()
    then Mount_WebUI ; fi
 }
 
+##----------------------------------------##
+## Modified by Martinski W. [2025-Jul-16] ##
+##----------------------------------------##
 TimeServer_Customise()
 {
 	TIMESERVER_NAME="$(TimeServer check)"
-	if [ -f "/opt/etc/init.d/S77$TIMESERVER_NAME" ]; then
+	if [ -f "/opt/etc/init.d/S77$TIMESERVER_NAME" ]
+	then
 		"/opt/etc/init.d/S77$TIMESERVER_NAME" stop >/dev/null 2>&1
 	fi
 	rm -f "/opt/etc/init.d/S77$TIMESERVER_NAME"
@@ -1156,10 +1165,12 @@ TimeServer_Customise()
 	then
 		mkdir -p /opt/var/lib/chrony
 		mkdir -p /opt/var/run/chrony
-		chown -R nobody:nobody /opt/var/lib/chrony
-		chown -R nobody:nobody /opt/var/run/chrony
 		chmod -R 770 /opt/var/lib/chrony
 		chmod -R 770 /opt/var/run/chrony
+		chown -R nobody:nobody /opt/var/lib/chrony
+		chown -R nobody:nobody /opt/var/run/chrony
+		[ ! -L /opt/etc/passwd ] && \
+		ln -snf /etc/passwd /opt/etc/passwd 2>/dev/null
 	fi
 	"/opt/etc/init.d/S77$TIMESERVER_NAME" start >/dev/null 2>&1
 }
@@ -3059,8 +3070,8 @@ Entware_Ready()
 ##----------------------------------------##
 Show_About()
 {
+	printf "About ${MGNTct}${SCRIPT_VERS_INFO}${CLRct}\n"
 	cat <<EOF
-About $SCRIPT_VERS_INFO
   $SCRIPT_NAME implements an NTP time server for AsusWRT Merlin
   with charts for daily, weekly and monthly summaries of performance.
   A choice between ntpd and chrony is available.
@@ -3084,8 +3095,8 @@ EOF
 ##----------------------------------------##
 Show_Help()
 {
+	printf "HELP ${MGNTct}${SCRIPT_VERS_INFO}${CLRct}\n"
 	cat <<EOF
-HELP $SCRIPT_VERS_INFO
 Available commands:
   $SCRIPT_NAME_LOWER about            explains functionality
   $SCRIPT_NAME_LOWER update           checks for updates
@@ -3096,8 +3107,8 @@ Available commands:
   $SCRIPT_NAME_LOWER generate         get modem stats and logs. also runs outputcsv
   $SCRIPT_NAME_LOWER outputcsv        create CSVs from database, used by WebUI and export
   $SCRIPT_NAME_LOWER ntpredirect      apply firewall rules to intercept and redirect NTP traffic
-  $SCRIPT_NAME_LOWER develop          switch to development branch
-  $SCRIPT_NAME_LOWER stable           switch to stable branch
+  $SCRIPT_NAME_LOWER develop          switch to development branch version
+  $SCRIPT_NAME_LOWER stable           switch to stable/production branch version
 EOF
 	printf "\n"
 }

--- a/timeserverd
+++ b/timeserverd
@@ -1,63 +1,112 @@
 #!/bin/sh
-#shellcheck disable=SC2039
-trap '' SIGHUP
+#
+# Last Modified: 2025-Jul-16
+#
+# shellcheck disable=SC2039 disable=SC3043
+#
+trap '' HUP
 
-# Wait for NTP before starting
-logger -st timeserverd "Waiting for NTP to sync before starting..."
+# Wait for NTP before starting #
+logger -st "timeserverd_[$$]" "Waiting for NTP to sync before starting..."
 ntpwaitcount=0
-while [ "$(nvram get ntp_ready)" -eq 0 ] && [ "$ntpwaitcount" -lt 600 ]; do
+while [ "$(nvram get ntp_ready)" -eq 0 ] && [ "$ntpwaitcount" -lt 600 ]
+do
 	ntpwaitcount="$((ntpwaitcount + 30))"
-	logger -st timeserverd "Waiting for NTP to sync..."
+	logger -st "timeserverd_[$$]" "Waiting for NTP to sync..."
 	sleep 30
 done
 
-if [ "$ntpwaitcount" -ge 600 ]; then
-	logger -st timeserverd "NTP failed to sync after 10 minutes - please check immediately!"
+if [ "$ntpwaitcount" -ge 600 ]
+then
+	logger -st "timeserverd_[$$]" "NTP failed to sync after 10 minutes - please check immediately!"
 	exit 1
 fi
 
-if [ -f "/opt/share/ntpmerlin.d/config" ]; then
+if [ -f "/opt/share/ntpmerlin.d/config" ]
+then
 	SCRIPT_STORAGE_DIR="/opt/share/ntpmerlin.d"
 else
 	SCRIPT_STORAGE_DIR="/jffs/addons/ntpmerlin.d"
 fi
 
-if [ "$1" = "S77ntpd" ]; then
+##-------------------------------------##
+## Added by Martinski W. [2025-Jul-16] ##
+##-------------------------------------##
+_IsZombieProcess_()
+{
+    if [ $# -eq 0 ] || [ -z "$1" ] || ! echo "$1" | grep -qE "^(ntpd|chronyd)$"
+    then return 1 ; fi
+
+    local theProcStr  thePIDnum  thePPIDnum  logMsg
+
+    theProcStr="$(/usr/bin/top -bn 1 | grep -w "$1" | grep -v "grep" | awk -F ' ' '{if ($4 == "Z") print $0}')"
+    if [ -z "$theProcStr" ]
+    then return 1  #Process OK#
+    fi
+
+    thePIDnum="$(echo "$theProcStr" | awk -F ' ' '{print $1}')"
+    thePPIDnum="$(echo "$theProcStr" | awk -F ' ' '{print $2}')"
+    logMsg="$(printf "A zombie '$1' process was found [PID=%d, PPID=%d]" "$thePIDnum" "$thePPIDnum")"
+    logger -t "timeserverd_[$$]" "$logMsg"
+
+    if [ -n "$thePPIDnum" ] && [ "$thePPIDnum" -gt 2 ]
+    then
+        kill -TERM "$thePPIDnum"
+        wait "$thePPIDnum"
+        if kill -EXIT "$thePPIDnum" 2>/dev/null
+        then
+            kill -KILL "$thePPIDnum"
+            wait "$thePPIDnum"
+        fi
+    fi
+
+    return 0
+}
+
+if [ "$1" = "S77ntpd" ]
+then
 	ntpd -c "$SCRIPT_STORAGE_DIR/ntp.conf" -g > /dev/null 2>&1 &
-	
-	while true; do
+	logger -t "timeserverd_[$$]" "ntpd was started"
+
+	while true
+	do
 		sleep 5
-		if [ "$(pidof ntpd | wc -w)" -lt 1 ]; then
-			logger -t timeserverd "ntpd dead, restarting..."
-			killall -q ntpd
-			sleep 5
+		if [ "$(pidof ntpd | wc -w)" -eq 0 ] || _IsZombieProcess_ ntpd
+		then
+			logger -t "timeserverd_[$$]" "ntpd dead, restarting..."
 			ntpd -c "$SCRIPT_STORAGE_DIR/ntp.conf" -g > /dev/null 2>&1 &
-			logger -t timeserverd "ntpd restarted"
+			logger -t "timeserverd_[$$]" "ntpd was restarted"
 		fi
 	done
-elif [ "$1" = "S77chronyd" ]; then
-	if [ -f /opt/etc/init.d/S06chronyd ]; then
+
+elif [ "$1" = "S77chronyd" ]
+then
+	if [ -f /opt/etc/init.d/S06chronyd ]
+	then
 		/opt/etc/init.d/S06chronyd stop
 		rm -f /opt/etc/init.d/S06chronyd
 	fi
-	
+
 	mkdir -p /opt/var/lib/chrony
 	mkdir -p /opt/var/run/chrony
-	chown -R nobody:nobody /opt/var/lib/chrony
-	chown -R nobody:nobody /opt/var/run/chrony
 	chmod -R 770 /opt/var/lib/chrony
 	chmod -R 770 /opt/var/run/chrony
-	
+	chown -R nobody:nobody /opt/var/lib/chrony
+	chown -R nobody:nobody /opt/var/run/chrony
+	[ ! -L /opt/etc/passwd ] && \
+	ln -snf /etc/passwd /opt/etc/passwd 2>/dev/null
+
 	chronyd -r -u nobody -f "$SCRIPT_STORAGE_DIR/chrony.conf" > /dev/null 2>&1 &
-	
-	while true; do
+	logger -t "timeserverd_[$$]" "chronyd was started"
+
+	while true
+	do
 		sleep 5
-		if [ "$(pidof chronyd | wc -w)" -lt 1 ]; then
-			logger -t timeserverd "chronyd dead, restarting..."
-			killall -q chronyd
-			sleep 5
+		if [ "$(pidof chronyd | wc -w)" -eq 0 ] || _IsZombieProcess_ chronyd
+		then
+			logger -t "timeserverd_[$$]" "chronyd dead, restarting..."
 			chronyd -r -u nobody -f "$SCRIPT_STORAGE_DIR/chrony.conf" > /dev/null 2>&1 &
-			logger -t timeserverd "chronyd restarted"
+			logger -t "timeserverd_[$$]" "chronyd was restarted"
 		fi
 	done
 fi


### PR DESCRIPTION
- Fixed issue with missing symbolic link for "`/opt/etc/passwd`" which causes the '`chronyd`' process to fail, resulting in an infinite loop trying to restart the process every 5 seconds.
   [Thanks to GitHub user @trisk for reporting the problem and providing a fix]

- Miscellaneous improvements.