### PR TITLE
Code Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ntpMerlin
 
 ## v3.4.10
-### Updated on 2025-Jul-29
+### Updated on 2025-Jul-31
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.
 

--- a/S77chronyd
+++ b/S77chronyd
@@ -1,9 +1,13 @@
 #!/bin/sh
+#
+# Last Modified: 2025-Jul-30
 # shellcheck disable=SC2034
+#
 ln -s /jffs/addons/ntpmerlin.d/timeserverd /opt/bin 2>/dev/null
 chmod 0755 /opt/bin/timeserverd
 
-if [ "$1" = "restart" ] || [ "$1" = "stop" ] || [ "$1" = "kill" ]; then
+if [ "$1" = "restart" ] || [ "$1" = "stop" ] || [ "$1" = "kill" ]
+then
 	killall -q timeserverd
 	killall -q chronyd
 fi

--- a/S77ntpd
+++ b/S77ntpd
@@ -1,9 +1,13 @@
 #!/bin/sh
+#
+# Last Modified: 2025-Jul-30
 # shellcheck disable=SC2034
+#
 ln -s /jffs/addons/ntpmerlin.d/timeserverd /opt/bin 2>/dev/null
 chmod 0755 /opt/bin/timeserverd
 
-if [ "$1" = "restart" ] || [ "$1" = "stop" ] || [ "$1" = "kill" ]; then
+if [ "$1" = "restart" ] || [ "$1" = "stop" ] || [ "$1" = "kill" ]
+then
 	killall -q timeserverd
 	killall -q ntpd
 fi


### PR DESCRIPTION
Added code to double-check and make sure that the correct time server script installed by ntpMerlin (for `ntpd` or `chronyd`) is found and launched. This check is performed at startup following a reboot, every time the time server is restarted, and every 10 minutes via the pre-existing cron job that generates time server stats.
