### PR TITLE
Fixes and Improvements.

### DIFF
--- a/.github/workflows/Create-NewReleases.yml
+++ b/.github/workflows/Create-NewReleases.yml
@@ -97,7 +97,7 @@ jobs:
 
       # 7--- Publish a GitHub Release with auto-generated notes
       - name: Create Release with Automated Release Notes
-        uses: softprops/action-gh-release@v2.2.2
+        uses: softprops/action-gh-release@v2.3.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.nextver.outputs.tag }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ntpMerlin
 
-## v3.4.9
-### Updated on 2025-Jul-25
+## v3.4.10
+### Updated on 2025-Jul-29
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ntpMerlin
 
 ## v3.4.9
-### Updated on 2025-Jul-20
+### Updated on 2025-Jul-25
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ntpMerlin
 
 ## v3.4.10
-### Updated on 2025-Jul-29
+### Updated on 2025-Jul-31
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ntpMerlin
 
 ## v3.4.9
-### Updated on 2025-July-16
+### Updated on 2025-Jul-20
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ntpMerlin
 
-## v3.4.8
-### Updated on 2025-June-21
+## v3.4.9
+### Updated on 2025-July-16
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.
 

--- a/S77chronyd
+++ b/S77chronyd
@@ -1,9 +1,13 @@
 #!/bin/sh
+#
+# Last Modified: 2025-Jul-30
 # shellcheck disable=SC2034
+#
 ln -s /jffs/addons/ntpmerlin.d/timeserverd /opt/bin 2>/dev/null
 chmod 0755 /opt/bin/timeserverd
 
-if [ "$1" = "restart" ] || [ "$1" = "stop" ] || [ "$1" = "kill" ]; then
+if [ "$1" = "restart" ] || [ "$1" = "stop" ] || [ "$1" = "kill" ]
+then
 	killall -q timeserverd
 	killall -q chronyd
 fi

--- a/S77chronyd
+++ b/S77chronyd
@@ -8,7 +8,6 @@ if [ "$1" = "restart" ] || [ "$1" = "stop" ] || [ "$1" = "kill" ]; then
 	killall -q chronyd
 fi
 
-
 ENABLED=yes
 PROCS=timeserverd
 ARGS="S77chronyd"

--- a/S77ntpd
+++ b/S77ntpd
@@ -1,9 +1,13 @@
 #!/bin/sh
+#
+# Last Modified: 2025-Jul-30
 # shellcheck disable=SC2034
+#
 ln -s /jffs/addons/ntpmerlin.d/timeserverd /opt/bin 2>/dev/null
 chmod 0755 /opt/bin/timeserverd
 
-if [ "$1" = "restart" ] || [ "$1" = "stop" ] || [ "$1" = "kill" ]; then
+if [ "$1" = "restart" ] || [ "$1" = "stop" ] || [ "$1" = "kill" ]
+then
 	killall -q timeserverd
 	killall -q ntpd
 fi

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -14,7 +14,7 @@
 ##     Forked from https://github.com/jackyaz/ntpMerlin     ##
 ##                                                          ##
 ##############################################################
-# Last Modified: 2025-Jun-21
+# Last Modified: 2025-Jul-16
 #-------------------------------------------------------------
 
 ###############       Shellcheck directives      #############
@@ -36,8 +36,8 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="ntpMerlin"
 readonly SCRIPT_NAME_LOWER="$(echo "$SCRIPT_NAME" | tr 'A-Z' 'a-z' | sed 's/d//')"
-readonly SCRIPT_VERSION="v3.4.8"
-readonly SCRIPT_VERSTAG="25062121"
+readonly SCRIPT_VERSION="v3.4.9"
+readonly SCRIPT_VERSTAG="25071601"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
@@ -68,7 +68,6 @@ readonly scriptVERINFO="[${SCRIPT_VERSION}_${SCRIPT_VERSTAG}, Branch: $SCRIPT_BR
 readonly defTrimDB_Hour=3
 readonly defTrimDB_Mins=7
 
-readonly oneHrSec=3600
 readonly _12Hours=43200
 readonly _24Hours=86400
 readonly _36Hours=129600
@@ -104,6 +103,7 @@ readonly CLEARFORMAT="\\e[0m"
 readonly CLRct="\e[0m"
 readonly REDct="\e[1;31m"
 readonly GRNct="\e[1;32m"
+readonly MGNTct="\e[1;35m"
 readonly CritIREDct="\e[41m"
 readonly CritBREDct="\e[30;101m"
 readonly PassBGRNct="\e[30;102m"
@@ -291,10 +291,12 @@ Update_Version()
 					Update_File shared-jy.tar.gz
 					Update_File timeserverd
 					TIMESERVER_NAME="$(TimeServer check)"
-					if [ "$TIMESERVER_NAME" = "ntpd" ]; then
+					if [ "$TIMESERVER_NAME" = "ntpd" ]
+					then
 						Update_File S77ntpd
 						Update_File ntp.conf
-					elif [ "$TIMESERVER_NAME" = "chronyd" ]; then
+					elif [ "$TIMESERVER_NAME" = "chronyd" ]
+					then
 						Update_File S77chronyd
 						Update_File chrony.conf
 					fi
@@ -329,10 +331,12 @@ Update_Version()
 		Update_File shared-jy.tar.gz
 		Update_File timeserverd
 		TIMESERVER_NAME="$(TimeServer check)"
-		if [ "$TIMESERVER_NAME" = "ntpd" ]; then
+		if [ "$TIMESERVER_NAME" = "ntpd" ]
+		then
 			Update_File ntp.conf
 			Update_File S77ntpd
-		elif [ "$TIMESERVER_NAME" = "chronyd" ]; then
+		elif [ "$TIMESERVER_NAME" = "chronyd" ]
+		then
 			Update_File chrony.conf
 			Update_File S77chronyd
 		fi
@@ -364,7 +368,8 @@ Update_File()
 	then
 		tmpfile="/tmp/$1"
 		Download_File "$SCRIPT_REPO/$1" "$tmpfile"
-		if ! diff -q "$tmpfile" "/opt/etc/init.d/$1" >/dev/null 2>&1; then
+		if ! diff -q "$tmpfile" "/opt/etc/init.d/$1" >/dev/null 2>&1
+		then
 			Print_Output true "New version of $1 downloaded" "$PASS"
 			TimeServer_Customise
 		fi
@@ -557,15 +562,15 @@ Create_Dirs()
 Create_Symlinks()
 {
 	rm -rf "${SCRIPT_WEB_DIR:?}/"* 2>/dev/null
-	
+
 	ln -s /tmp/detect_ntpmerlin.js "$SCRIPT_WEB_DIR/detect_ntpmerlin.js" 2>/dev/null
 	ln -s "$SCRIPT_STORAGE_DIR/ntpstatstext.js" "$SCRIPT_WEB_DIR/ntpstatstext.js" 2>/dev/null
 	ln -s "$SCRIPT_STORAGE_DIR/lastx.csv" "$SCRIPT_WEB_DIR/lastx.htm" 2>/dev/null
-	
+
 	ln -s "$SCRIPT_CONF" "$SCRIPT_WEB_DIR/config.htm" 2>/dev/null
-	
+
 	ln -s "$CSV_OUTPUT_DIR" "$SCRIPT_WEB_DIR/csv" 2>/dev/null
-	
+
 	if [ ! -d "$SHARED_WEB_DIR" ]; then
 		ln -s "$SHARED_DIR" "$SHARED_WEB_DIR" 2>/dev/null
 	fi
@@ -1143,10 +1148,14 @@ _CheckFor_WebGUI_Page_()
    then Mount_WebUI ; fi
 }
 
+##----------------------------------------##
+## Modified by Martinski W. [2025-Jul-16] ##
+##----------------------------------------##
 TimeServer_Customise()
 {
 	TIMESERVER_NAME="$(TimeServer check)"
-	if [ -f "/opt/etc/init.d/S77$TIMESERVER_NAME" ]; then
+	if [ -f "/opt/etc/init.d/S77$TIMESERVER_NAME" ]
+	then
 		"/opt/etc/init.d/S77$TIMESERVER_NAME" stop >/dev/null 2>&1
 	fi
 	rm -f "/opt/etc/init.d/S77$TIMESERVER_NAME"
@@ -1156,10 +1165,12 @@ TimeServer_Customise()
 	then
 		mkdir -p /opt/var/lib/chrony
 		mkdir -p /opt/var/run/chrony
-		chown -R nobody:nobody /opt/var/lib/chrony
-		chown -R nobody:nobody /opt/var/run/chrony
 		chmod -R 770 /opt/var/lib/chrony
 		chmod -R 770 /opt/var/run/chrony
+		chown -R nobody:nobody /opt/var/lib/chrony
+		chown -R nobody:nobody /opt/var/run/chrony
+		[ ! -L /opt/etc/passwd ] && \
+		ln -snf /etc/passwd /opt/etc/passwd 2>/dev/null
 	fi
 	"/opt/etc/init.d/S77$TIMESERVER_NAME" start >/dev/null 2>&1
 }
@@ -3059,8 +3070,8 @@ Entware_Ready()
 ##----------------------------------------##
 Show_About()
 {
+	printf "About ${MGNTct}${SCRIPT_VERS_INFO}${CLRct}\n"
 	cat <<EOF
-About $SCRIPT_VERS_INFO
   $SCRIPT_NAME implements an NTP time server for AsusWRT Merlin
   with charts for daily, weekly and monthly summaries of performance.
   A choice between ntpd and chrony is available.
@@ -3084,8 +3095,8 @@ EOF
 ##----------------------------------------##
 Show_Help()
 {
+	printf "HELP ${MGNTct}${SCRIPT_VERS_INFO}${CLRct}\n"
 	cat <<EOF
-HELP $SCRIPT_VERS_INFO
 Available commands:
   $SCRIPT_NAME_LOWER about            explains functionality
   $SCRIPT_NAME_LOWER update           checks for updates
@@ -3096,8 +3107,8 @@ Available commands:
   $SCRIPT_NAME_LOWER generate         get modem stats and logs. also runs outputcsv
   $SCRIPT_NAME_LOWER outputcsv        create CSVs from database, used by WebUI and export
   $SCRIPT_NAME_LOWER ntpredirect      apply firewall rules to intercept and redirect NTP traffic
-  $SCRIPT_NAME_LOWER develop          switch to development branch
-  $SCRIPT_NAME_LOWER stable           switch to stable branch
+  $SCRIPT_NAME_LOWER develop          switch to development branch version
+  $SCRIPT_NAME_LOWER stable           switch to stable/production branch version
 EOF
 	printf "\n"
 }

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -14,7 +14,7 @@
 ##     Forked from https://github.com/jackyaz/ntpMerlin     ##
 ##                                                          ##
 ##############################################################
-# Last Modified: 2025-Jul-16
+# Last Modified: 2025-Jul-20
 #-------------------------------------------------------------
 
 ###############       Shellcheck directives      #############
@@ -37,7 +37,7 @@
 readonly SCRIPT_NAME="ntpMerlin"
 readonly SCRIPT_NAME_LOWER="$(echo "$SCRIPT_NAME" | tr 'A-Z' 'a-z' | sed 's/d//')"
 readonly SCRIPT_VERSION="v3.4.9"
-readonly SCRIPT_VERSTAG="25071601"
+readonly SCRIPT_VERSTAG="25072022"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
@@ -62,7 +62,8 @@ readonly webPageLineTabExp="\{url: \"$webPageFileRegExp\", tabName: "
 readonly webPageLineRegExp="${webPageLineTabExp}\"$SCRIPT_NAME\"\},"
 readonly BEGIN_MenuAddOnsTag="/\*\*BEGIN:_AddOns_\*\*/"
 readonly ENDIN_MenuAddOnsTag="/\*\*ENDIN:_AddOns_\*\*/"
-readonly scriptVERINFO="[${SCRIPT_VERSION}_${SCRIPT_VERSTAG}, Branch: $SCRIPT_BRANCH]"
+readonly branchx_TAG="Branch: $SCRIPT_BRANCH"
+readonly version_TAG="${SCRIPT_VERSION}_${SCRIPT_VERSTAG}"
 
 # For daily CRON job to trim database #
 readonly defTrimDB_Hour=3
@@ -1859,7 +1860,7 @@ _SQLGetDBLogTimeStamp_()
 { printf "[$(date +"$sqlDBLogDateTime")]" ; }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2025-Jun-21] ##
+## Modified by Martinski W. [2025-Jul-20] ##
 ##----------------------------------------##
 readonly errorMsgsRegExp="Parse error|Runtime error|Error:"
 readonly corruptedBinExp="Illegal instruction|SQLite header and source version mismatch"
@@ -1947,7 +1948,7 @@ _ApplyDatabaseSQLCmds_()
     fi
     if "$foundError" || "$foundLocked"
     then
-        Print_Output true "SQLite process ${resultStr}" "$ERR"
+        Print_Output true "SQLite process[$callFlag] ${resultStr}" "$ERR"
     fi
 }
 
@@ -3137,9 +3138,9 @@ CSV_OUTPUT_DIR="$SCRIPT_STORAGE_DIR/csv"
 JFFS_LowFreeSpaceStatus="OK"
 updateJFFS_SpaceInfo=false
 
-if [ "$SCRIPT_BRANCH" != "develop" ]
-then SCRIPT_VERS_INFO=""
-else SCRIPT_VERS_INFO="$scriptVERINFO"
+if [ "$SCRIPT_BRANCH" = "master" ]
+then SCRIPT_VERS_INFO="[$branchx_TAG]"
+else SCRIPT_VERS_INFO="[$version_TAG, $branchx_TAG]"
 fi
 
 ##----------------------------------------##

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -37,7 +37,7 @@
 readonly SCRIPT_NAME="ntpMerlin"
 readonly SCRIPT_NAME_LOWER="$(echo "$SCRIPT_NAME" | tr 'A-Z' 'a-z' | sed 's/d//')"
 readonly SCRIPT_VERSION="v3.4.10"
-readonly SCRIPT_VERSTAG="25073100"
+readonly SCRIPT_VERSTAG="25073122"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
@@ -1172,12 +1172,12 @@ TimeServer_Customise()
 	if [ -f /opt/etc/init.d/S77ntpd ]
 	then
 		/opt/etc/init.d/S77ntpd stop >/dev/null 2>&1
-		sleep 2 ; killall -q ntpd ; sleep 2
+		sleep 2 ; killall -q ntpd ; sleep 1
 	fi
 	if [ -f /opt/etc/init.d/S77chronyd ]
 	then
 		/opt/etc/init.d/S77chronyd stop >/dev/null 2>&1
-		sleep 2 ; killall -q chronyd ; sleep 2
+		sleep 2 ; killall -q chronyd ; sleep 1
 	fi
 	rm -f /opt/etc/init.d/S77ntpd /opt/etc/init.d/S77chronyd
 
@@ -1224,7 +1224,7 @@ TimeServer_ServiceCheck()
            ! diff -q "$initTimeServerPath" "$ntpxTimeServerPath" >/dev/null 2>&1 
         then
             "$initTimeServerPath" stop >/dev/null 2>&1
-            sleep 2
+            sleep 2 ; killall "$TIMESERVER_ID"
             cp -fp "$ntpxTimeServerPath" "$initTimeServerPath"
             chmod a+x "$initTimeServerPath"
             "$initTimeServerPath" restart
@@ -1235,13 +1235,13 @@ TimeServer_ServiceCheck()
            [ -f /opt/etc/init.d/S77ntpd ]
         then
             /opt/etc/init.d/S77ntpd stop >/dev/null 2>&1
-            sleep 2 ; killall -q ntpd ; sleep 2
+            sleep 2 ; killall -q ntpd ; sleep 1
             rm -f /opt/etc/init.d/S77ntpd
         elif [ "$TIMESERVER_ID" = "ntpd" ] && \
              [ -f /opt/etc/init.d/S77chronyd ]
         then
             /opt/etc/init.d/S77chronyd stop >/dev/null 2>&1
-            sleep 2 ; killall -q chronyd ; sleep 2
+            sleep 2 ; killall -q chronyd ; sleep 1
             rm -f /opt/etc/init.d/S77chronyd
         fi
     fi
@@ -1356,7 +1356,7 @@ TimeServer()
 			printf "Please wait...\n"
 			sed -i 's/^TIMESERVER=.*$/TIMESERVER=ntpd/' "$SCRIPT_CONF"
 			/opt/etc/init.d/S77chronyd stop >/dev/null 2>&1
-			sleep 2 ; killall -q chronyd ; sleep 2
+			sleep 2 ; killall -q chronyd ; sleep 1
 			rm -f /opt/etc/init.d/S77chronyd
 			if [ ! -f /opt/sbin/ntpd ] && [ -x /opt/bin/opkg ]
 			then
@@ -1371,7 +1371,7 @@ TimeServer()
 			printf "Please wait...\n"
 			sed -i 's/^TIMESERVER=.*$/TIMESERVER=chronyd/' "$SCRIPT_CONF"
 			/opt/etc/init.d/S77ntpd stop >/dev/null 2>&1
-			sleep 2 ; killall -q ntpd ; sleep 2
+			sleep 2 ; killall -q ntpd ; sleep 1
 			rm -f /opt/etc/init.d/S77ntpd
 			if [ ! -f /opt/sbin/chronyd ] && [ -x /opt/bin/opkg ]
 			then
@@ -2538,7 +2538,7 @@ MainMenu()
 	if [ "$TIMESERVER_NAME_MENU" = "ntpd" ]
 	then CONFFILE_MENU="$SCRIPT_STORAGE_DIR/ntp.conf"
 	elif [ "$TIMESERVER_NAME_MENU" = "chronyd" ]
-    then CONFFILE_MENU="$SCRIPT_STORAGE_DIR/chrony.conf"
+	then CONFFILE_MENU="$SCRIPT_STORAGE_DIR/chrony.conf"
 	fi
 
 	storageLocStr="$(ScriptStorageLocation check | tr 'a-z' 'A-Z')"
@@ -2561,20 +2561,20 @@ MainMenu()
 	printf "1.    Update timeserver stats now\n"
 	printf "      Database size: ${SETTING}%s${CLEARFORMAT}\n\n" "$(_GetFileSize_ "$NTPDSTATS_DB" HRx)"
 	printf "2.    Toggle redirect of all NTP traffic to %s\n" "$SCRIPT_NAME"
-    printf "      Currently: ${ntpRedirectStatus}${CLEARFORMAT}\n\n"
+	printf "      Currently: ${ntpRedirectStatus}${CLEARFORMAT}\n\n"
 	printf "3.    Edit ${SETTING}%s${CLEARFORMAT} configuration file\n\n" "$(TimeServer check)"
 	printf "4.    Toggle time output mode\n"
-    printf "      Currently: ${SETTING}%s${CLEARFORMAT} time values will be used for CSV exports\n\n" "$(OutputTimeMode check)"
+	printf "      Currently: ${SETTING}%s${CLEARFORMAT} time values will be used for CSV exports\n\n" "$(OutputTimeMode check)"
 	printf "5.    Set number of timeserver stats to show in WebUI\n"
-    printf "      Currently: ${SETTING}%s results will be shown${CLEARFORMAT}\n\n" "$(LastXResults check)"
+	printf "      Currently: ${SETTING}%s results will be shown${CLEARFORMAT}\n\n" "$(LastXResults check)"
 	printf "6.    Set number of days data to keep in database\n"
-    printf "      Currently: ${SETTING}%s days data will be kept${CLEARFORMAT}\n\n" "$(DaysToKeep check)"
+	printf "      Currently: ${SETTING}%s days data will be kept${CLEARFORMAT}\n\n" "$(DaysToKeep check)"
 	printf "s.    Toggle storage location for stats and config\n"
-    printf "      Current location: ${SETTING}%s${CLEARFORMAT}\n" "$storageLocStr"
-    printf "      JFFS Available: ${jffsFreeSpaceStr}${CLEARFORMAT}\n\n"
+	printf "      Current location: ${SETTING}%s${CLEARFORMAT}\n" "$storageLocStr"
+	printf "      JFFS Available: ${jffsFreeSpaceStr}${CLEARFORMAT}\n\n"
 	printf "t.    Switch timeserver between ${SETTING}ntpd${CLRct} and ${SETTING}chronyd${CLRct}\n"
-    printf "      Currently: ${SETTING}%s${CLEARFORMAT}\n" "$(TimeServer check)"
-    printf "      Config location: ${SETTING}%s${CLEARFORMAT}\n\n" "$CONFFILE_MENU"
+	printf "      Currently: ${SETTING}%s${CLEARFORMAT}\n" "$(TimeServer check)"
+	printf "      Config location: ${SETTING}%s${CLEARFORMAT}\n\n" "$CONFFILE_MENU"
 	printf "r.    Restart ${SETTING}%s${CLEARFORMAT}\n\n" "$(TimeServer check)"
 	printf "u.    Check for updates\n"
 	printf "uf.   Update %s with latest version (force update)\n\n" "$SCRIPT_NAME"
@@ -3008,7 +3008,7 @@ _FindandRemoveMenuAddOnsSection_()
 }
 
 ##----------------------------------------##
-## Modified by Martinski W. [2025-Jul-30] ##
+## Modified by Martinski W. [2025-Jul-31] ##
 ##----------------------------------------##
 Menu_Uninstall()
 {
@@ -3031,8 +3031,8 @@ Menu_Uninstall()
 
 	Get_WebUI_Page "$SCRIPT_DIR/ntpdstats_www.asp"
 	if [ -n "$MyWebPage" ] && \
-       [ "$MyWebPage" != "NONE" ] && \
-       [ -f "$TEMP_MENU_TREE" ]
+	   [ "$MyWebPage" != "NONE" ] && \
+	   [ -f "$TEMP_MENU_TREE" ]
 	then
 		sed -i "\\~$MyWebPage~d" "$TEMP_MENU_TREE"
 		rm -f "$SCRIPT_WEBPAGE_DIR/$MyWebPage"
@@ -3047,8 +3047,18 @@ Menu_Uninstall()
 	rm -rf "$SCRIPT_WEB_DIR" 2>/dev/null
 
 	Shortcut_Script delete
-	TIMESERVER_NAME="$(TimeServer check)"
-	"/opt/etc/init.d/S77$TIMESERVER_NAME" stop >/dev/null 2>&1
+
+    if [ -f /opt/etc/init.d/S77ntpd ]
+	then
+		/opt/etc/init.d/S77ntpd stop >/dev/null 2>&1
+		sleep 2 ; killall -q ntpd ; sleep 1
+	fi
+	if [ -f /opt/etc/init.d/S77chronyd ]
+	then
+		/opt/etc/init.d/S77chronyd stop >/dev/null 2>&1
+		sleep 2 ; killall -q chronyd ; sleep 1
+	fi
+
 	opkg remove --autoremove ntpd
 	opkg remove --autoremove ntp-utils
 	opkg remove --autoremove chrony

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -14,7 +14,7 @@
 ##     Forked from https://github.com/jackyaz/ntpMerlin     ##
 ##                                                          ##
 ##############################################################
-# Last Modified: 2025-Jul-20
+# Last Modified: 2025-Jul-25
 #-------------------------------------------------------------
 
 ###############       Shellcheck directives      #############
@@ -36,8 +36,8 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="ntpMerlin"
 readonly SCRIPT_NAME_LOWER="$(echo "$SCRIPT_NAME" | tr 'A-Z' 'a-z' | sed 's/d//')"
-readonly SCRIPT_VERSION="v3.4.9"
-readonly SCRIPT_VERSTAG="25072022"
+readonly SCRIPT_VERSION="v3.4.10"
+readonly SCRIPT_VERSTAG="25072522"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
@@ -3019,13 +3019,14 @@ NTP_Ready()
 			sleep "$theSleepDelay"
 			ntpWaitSecs="$((ntpWaitSecs + theSleepDelay))"
 		done
+
 		if [ "$ntpWaitSecs" -ge "$ntpMaxWaitSecs" ]
 		then
 			Print_Output true "NTP failed to sync after 10 minutes. Please resolve!" "$CRIT"
 			Clear_Lock
 			exit 1
 		else
-			Print_Output true "NTP synced, $SCRIPT_NAME will now continue" "$PASS"
+			Print_Output true "NTP has synced [$ntpWaitSecs secs]. $SCRIPT_NAME will now continue." "$PASS"
 			Clear_Lock
 		fi
 	fi
@@ -3053,13 +3054,14 @@ Entware_Ready()
 			sleep "$theSleepDelay"
 			sleepTimerSecs="$((sleepTimerSecs + theSleepDelay))"
 		done
+
 		if [ ! -f /opt/bin/opkg ]
 		then
 			Print_Output true "Entware NOT found and is required for $SCRIPT_NAME to run, please resolve!" "$CRIT"
 			Clear_Lock
 			exit 1
 		else
-			Print_Output true "Entware found. $SCRIPT_NAME will now continue" "$PASS"
+			Print_Output true "Entware found [$sleepTimerSecs secs]. $SCRIPT_NAME will now continue." "$PASS"
 			Clear_Lock
 		fi
 	fi

--- a/timeserverd
+++ b/timeserverd
@@ -1,24 +1,44 @@
 #!/bin/sh
 #
-# Last Modified: 2025-Jul-16
+# Last Modified: 2025-Jul-27
 #
 # shellcheck disable=SC2039 disable=SC3043
 #
 trap '' HUP
 
-# Wait for NTP before starting #
-logger -st "timeserverd_[$$]" "Waiting for NTP to sync before starting..."
-ntpwaitcount=0
-while [ "$(nvram get ntp_ready)" -eq 0 ] && [ "$ntpwaitcount" -lt 600 ]
-do
-	ntpwaitcount="$((ntpwaitcount + 30))"
-	logger -st "timeserverd_[$$]" "Waiting for NTP to sync..."
-	sleep 30
-done
+readonly logTagStr="timeserverd_[$$]"
 
-if [ "$ntpwaitcount" -ge 600 ]
+##-------------------------------------##
+## Added by Martinski W. [2025-Jul-27] ##
+##-------------------------------------##
+WaitFor_NTP_Ready()
+{
+    local theSleepDelay=15  ntpMaxWaitSecs=600  ntpWaitSecs
+
+    [ "$(nvram get ntp_ready)" -eq 1 ] && return 0
+
+    ntpWaitSecs=0
+    logger -st "$logTagStr" "Waiting for NTP to sync before starting..."
+
+    while [ "$(nvram get ntp_ready)" -eq 0 ] && [ "$ntpWaitSecs" -lt "$ntpMaxWaitSecs" ]
+    do
+        sleep "$theSleepDelay"
+        ntpWaitSecs="$((ntpWaitSecs + theSleepDelay))"
+        if [ "$((ntpWaitSecs % 30))" -eq 0 ]
+        then
+            logger -st "$logTagStr" "Waiting for NTP to sync [$ntpWaitSecs secs]..."
+        fi
+    done
+
+    [ "$ntpWaitSecs" -ge "$ntpMaxWaitSecs" ] && return 1
+    logger -st "$logTagStr" "NTP has synced [$ntpWaitSecs secs]."
+    return 0
+}
+
+# Wait for NTP before starting #
+if ! WaitFor_NTP_Ready
 then
-	logger -st "timeserverd_[$$]" "NTP failed to sync after 10 minutes - please check immediately!"
+	logger -st "$logTagStr" "NTP failed to sync after 10 minutes - please check immediately!"
 	exit 1
 fi
 
@@ -47,7 +67,7 @@ _IsZombieProcess_()
     thePIDnum="$(echo "$theProcStr" | awk -F ' ' '{print $1}')"
     thePPIDnum="$(echo "$theProcStr" | awk -F ' ' '{print $2}')"
     logMsg="$(printf "A zombie '$1' process was found [PID=%d, PPID=%d]" "$thePIDnum" "$thePPIDnum")"
-    logger -t "timeserverd_[$$]" "$logMsg"
+    logger -t "$logTagStr" "$logMsg"
 
     if [ -n "$thePPIDnum" ] && [ "$thePPIDnum" -gt 2 ]
     then
@@ -66,16 +86,16 @@ _IsZombieProcess_()
 if [ "$1" = "S77ntpd" ]
 then
 	ntpd -c "$SCRIPT_STORAGE_DIR/ntp.conf" -g > /dev/null 2>&1 &
-	logger -t "timeserverd_[$$]" "ntpd was started"
+	logger -t "$logTagStr" "ntpd was started"
 
 	while true
 	do
 		sleep 5
 		if [ "$(pidof ntpd | wc -w)" -eq 0 ] || _IsZombieProcess_ ntpd
 		then
-			logger -t "timeserverd_[$$]" "ntpd dead, restarting..."
+			logger -t "$logTagStr" "ntpd dead, restarting..."
 			ntpd -c "$SCRIPT_STORAGE_DIR/ntp.conf" -g > /dev/null 2>&1 &
-			logger -t "timeserverd_[$$]" "ntpd was restarted"
+			logger -t "$logTagStr" "ntpd was restarted"
 		fi
 	done
 
@@ -97,16 +117,16 @@ then
 	ln -snf /etc/passwd /opt/etc/passwd 2>/dev/null
 
 	chronyd -r -u nobody -f "$SCRIPT_STORAGE_DIR/chrony.conf" > /dev/null 2>&1 &
-	logger -t "timeserverd_[$$]" "chronyd was started"
+	logger -t "$logTagStr" "chronyd was started"
 
 	while true
 	do
 		sleep 5
 		if [ "$(pidof chronyd | wc -w)" -eq 0 ] || _IsZombieProcess_ chronyd
 		then
-			logger -t "timeserverd_[$$]" "chronyd dead, restarting..."
+			logger -t "$logTagStr" "chronyd dead, restarting..."
 			chronyd -r -u nobody -f "$SCRIPT_STORAGE_DIR/chrony.conf" > /dev/null 2>&1 &
-			logger -t "timeserverd_[$$]" "chronyd was restarted"
+			logger -t "$logTagStr" "chronyd was restarted"
 		fi
 	done
 fi

--- a/timeserverd
+++ b/timeserverd
@@ -1,63 +1,112 @@
 #!/bin/sh
-#shellcheck disable=SC2039
-trap '' SIGHUP
+#
+# Last Modified: 2025-Jul-16
+#
+# shellcheck disable=SC2039 disable=SC3043
+#
+trap '' HUP
 
-# Wait for NTP before starting
-logger -st timeserverd "Waiting for NTP to sync before starting..."
+# Wait for NTP before starting #
+logger -st "timeserverd_[$$]" "Waiting for NTP to sync before starting..."
 ntpwaitcount=0
-while [ "$(nvram get ntp_ready)" -eq 0 ] && [ "$ntpwaitcount" -lt 600 ]; do
+while [ "$(nvram get ntp_ready)" -eq 0 ] && [ "$ntpwaitcount" -lt 600 ]
+do
 	ntpwaitcount="$((ntpwaitcount + 30))"
-	logger -st timeserverd "Waiting for NTP to sync..."
+	logger -st "timeserverd_[$$]" "Waiting for NTP to sync..."
 	sleep 30
 done
 
-if [ "$ntpwaitcount" -ge 600 ]; then
-	logger -st timeserverd "NTP failed to sync after 10 minutes - please check immediately!"
+if [ "$ntpwaitcount" -ge 600 ]
+then
+	logger -st "timeserverd_[$$]" "NTP failed to sync after 10 minutes - please check immediately!"
 	exit 1
 fi
 
-if [ -f "/opt/share/ntpmerlin.d/config" ]; then
+if [ -f "/opt/share/ntpmerlin.d/config" ]
+then
 	SCRIPT_STORAGE_DIR="/opt/share/ntpmerlin.d"
 else
 	SCRIPT_STORAGE_DIR="/jffs/addons/ntpmerlin.d"
 fi
 
-if [ "$1" = "S77ntpd" ]; then
+##-------------------------------------##
+## Added by Martinski W. [2025-Jul-16] ##
+##-------------------------------------##
+_IsZombieProcess_()
+{
+    if [ $# -eq 0 ] || [ -z "$1" ] || ! echo "$1" | grep -qE "^(ntpd|chronyd)$"
+    then return 1 ; fi
+
+    local theProcStr  thePIDnum  thePPIDnum  logMsg
+
+    theProcStr="$(/usr/bin/top -bn 1 | grep -w "$1" | grep -v "grep" | awk -F ' ' '{if ($4 == "Z") print $0}')"
+    if [ -z "$theProcStr" ]
+    then return 1  #Process OK#
+    fi
+
+    thePIDnum="$(echo "$theProcStr" | awk -F ' ' '{print $1}')"
+    thePPIDnum="$(echo "$theProcStr" | awk -F ' ' '{print $2}')"
+    logMsg="$(printf "A zombie '$1' process was found [PID=%d, PPID=%d]" "$thePIDnum" "$thePPIDnum")"
+    logger -t "timeserverd_[$$]" "$logMsg"
+
+    if [ -n "$thePPIDnum" ] && [ "$thePPIDnum" -gt 2 ]
+    then
+        kill -TERM "$thePPIDnum"
+        wait "$thePPIDnum"
+        if kill -EXIT "$thePPIDnum" 2>/dev/null
+        then
+            kill -KILL "$thePPIDnum"
+            wait "$thePPIDnum"
+        fi
+    fi
+
+    return 0
+}
+
+if [ "$1" = "S77ntpd" ]
+then
 	ntpd -c "$SCRIPT_STORAGE_DIR/ntp.conf" -g > /dev/null 2>&1 &
-	
-	while true; do
+	logger -t "timeserverd_[$$]" "ntpd was started"
+
+	while true
+	do
 		sleep 5
-		if [ "$(pidof ntpd | wc -w)" -lt 1 ]; then
-			logger -t timeserverd "ntpd dead, restarting..."
-			killall -q ntpd
-			sleep 5
+		if [ "$(pidof ntpd | wc -w)" -eq 0 ] || _IsZombieProcess_ ntpd
+		then
+			logger -t "timeserverd_[$$]" "ntpd dead, restarting..."
 			ntpd -c "$SCRIPT_STORAGE_DIR/ntp.conf" -g > /dev/null 2>&1 &
-			logger -t timeserverd "ntpd restarted"
+			logger -t "timeserverd_[$$]" "ntpd was restarted"
 		fi
 	done
-elif [ "$1" = "S77chronyd" ]; then
-	if [ -f /opt/etc/init.d/S06chronyd ]; then
+
+elif [ "$1" = "S77chronyd" ]
+then
+	if [ -f /opt/etc/init.d/S06chronyd ]
+	then
 		/opt/etc/init.d/S06chronyd stop
 		rm -f /opt/etc/init.d/S06chronyd
 	fi
-	
+
 	mkdir -p /opt/var/lib/chrony
 	mkdir -p /opt/var/run/chrony
-	chown -R nobody:nobody /opt/var/lib/chrony
-	chown -R nobody:nobody /opt/var/run/chrony
 	chmod -R 770 /opt/var/lib/chrony
 	chmod -R 770 /opt/var/run/chrony
-	
+	chown -R nobody:nobody /opt/var/lib/chrony
+	chown -R nobody:nobody /opt/var/run/chrony
+	[ ! -L /opt/etc/passwd ] && \
+	ln -snf /etc/passwd /opt/etc/passwd 2>/dev/null
+
 	chronyd -r -u nobody -f "$SCRIPT_STORAGE_DIR/chrony.conf" > /dev/null 2>&1 &
-	
-	while true; do
+	logger -t "timeserverd_[$$]" "chronyd was started"
+
+	while true
+	do
 		sleep 5
-		if [ "$(pidof chronyd | wc -w)" -lt 1 ]; then
-			logger -t timeserverd "chronyd dead, restarting..."
-			killall -q chronyd
-			sleep 5
+		if [ "$(pidof chronyd | wc -w)" -eq 0 ] || _IsZombieProcess_ chronyd
+		then
+			logger -t "timeserverd_[$$]" "chronyd dead, restarting..."
 			chronyd -r -u nobody -f "$SCRIPT_STORAGE_DIR/chrony.conf" > /dev/null 2>&1 &
-			logger -t timeserverd "chronyd restarted"
+			logger -t "timeserverd_[$$]" "chronyd was restarted"
 		fi
 	done
 fi

--- a/timeserverd
+++ b/timeserverd
@@ -1,11 +1,12 @@
 #!/bin/sh
 #
-# Last Modified: 2025-Jul-27
+# Last Modified: 2025-Jul-29
 #
 # shellcheck disable=SC2039 disable=SC3043
 #
 trap '' HUP
 
+readonly VERSIONstr="3.4.10"
 readonly logTagStr="timeserverd_[$$]"
 
 ##-------------------------------------##
@@ -35,7 +36,6 @@ WaitFor_NTP_Ready()
     return 0
 }
 
-# Wait for NTP before starting #
 if ! WaitFor_NTP_Ready
 then
 	logger -st "$logTagStr" "NTP failed to sync after 10 minutes - please check immediately!"
@@ -83,8 +83,18 @@ _IsZombieProcess_()
     return 0
 }
 
+##----------------------------------------##
+## Modified by Martinski W. [2025-Jul-29] ##
+##----------------------------------------##
 if [ "$1" = "S77ntpd" ]
 then
+	if [ -f /opt/etc/init.d/S77chronyd ]
+	then
+		/opt/etc/init.d/S77chronyd stop >/dev/null 2>&1
+		sleep 2 ; killall -q chronyd ; sleep 2
+		rm -f /opt/etc/init.d/S77chronyd
+	fi
+
 	ntpd -c "$SCRIPT_STORAGE_DIR/ntp.conf" -g > /dev/null 2>&1 &
 	logger -t "$logTagStr" "ntpd was started"
 
@@ -101,10 +111,17 @@ then
 
 elif [ "$1" = "S77chronyd" ]
 then
+	if [ -f /opt/etc/init.d/S77ntpd ]
+	then
+		/opt/etc/init.d/S77ntpd stop >/dev/null 2>&1
+		sleep 2 ; killall -q ntpd ; sleep 2
+		rm -f /opt/etc/init.d/S77ntpd
+	fi
+
 	if [ -f /opt/etc/init.d/S06chronyd ]
 	then
-		/opt/etc/init.d/S06chronyd stop
-		rm -f /opt/etc/init.d/S06chronyd
+		/opt/etc/init.d/S06chronyd stop >/dev/null 2>&1
+		sleep 2 ; rm -f /opt/etc/init.d/S06chronyd
 	fi
 
 	mkdir -p /opt/var/lib/chrony


### PR DESCRIPTION
- Added code to double-check and make sure only one NTP server process (either `ntpd` or `chronyd`) is running after toggling the time server selection and every time the corresponding service script is executed (started or restarted).

- Added code to double-check and make sure that the correct time server script installed by ntpMerlin (for `ntpd` or `chronyd`) is found and executed, and to verify that it has not been overwritten or modified (e.g. via Entware package updates). These checks are performed at startup following a reboot, every time the NTP server is restarted, and every 10 minutes via the pre-existing cron job that generates time server stats.

- Miscellaneous code improvements.