### PR TITLE
Workaround for Entware Binaries using RUNPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ntpMerlin
 
-## v3.4.14
-### Updated on 2026-Mar-15
+## v3.4.15
+### Updated on 2026-Apr-11
 
 ## About
 ntpMerlin implements an NTP time server for AsusWRT Merlin with charts for daily, weekly and monthly summaries of performance. A choice between ntpd and chrony is available.

--- a/ntpmerlin.sh
+++ b/ntpmerlin.sh
@@ -14,7 +14,7 @@
 ##     Forked from https://github.com/jackyaz/ntpMerlin     ##
 ##                                                          ##
 ##############################################################
-# Last Modified: 2026-Mar-15
+# Last Modified: 2026-Apr-11
 #-------------------------------------------------------------
 
 ###############       Shellcheck directives      #############
@@ -36,8 +36,8 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="ntpMerlin"
 readonly SCRIPT_NAME_LOWER="$(echo "$SCRIPT_NAME" | tr 'A-Z' 'a-z' | sed 's/d//')"
-readonly SCRIPT_VERSION="v3.4.14"
-readonly SCRIPT_VERSTAG="26031520"
+readonly SCRIPT_VERSION="v3.4.15"
+readonly SCRIPT_VERSTAG="26041103"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/AMTM-OSR/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
@@ -119,6 +119,9 @@ readonly BOLDUNDERLN="\e[1;4m"
 readonly menuSepStr="${BOLD}##############################################################${CLRct}"
 
 ### End of output format variables ###
+
+# Workaround for Entware ELF binaries compiled with RUNPATH #
+unset LD_LIBRARY_PATH
 
 # Give priority to built-in binaries #
 export PATH="/bin:/usr/bin:/sbin:/usr/sbin:$PATH"

--- a/timeserverd
+++ b/timeserverd
@@ -1,13 +1,16 @@
 #!/bin/sh
 #
-# Last Modified: 2026-Mar-15
+# Last Modified: 2026-Apr-11
 #
 # shellcheck disable=SC2039 disable=SC3043
 #
 trap '' HUP
 
-readonly VERSIONstr="3.4.14"
+readonly VERSIONstr="3.4.15"
 readonly logTagStr="timeserverd_[$$]"
+
+# Workaround for Entware ELF binaries compiled with RUNPATH #
+unset LD_LIBRARY_PATH
 
 ##-------------------------------------##
 ## Added by Martinski W. [2025-Jul-27] ##


### PR DESCRIPTION
Added "`unset LD_LIBRARY_PATH`" line as a workaround due to the latest Entware binaries using the **RUNPATH** embedded library search path mechanism instead of the previous **RPATH** method. RUNPATH is searched **AFTER** the LD_LIBRARY_PATH definitions, whereas **RPATH** has higher priority than the LD_LIBRARY_PATH environment variable, so it's searched **FIRST**.

